### PR TITLE
Workaround to preserve file permission on macOS

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,8 +71,10 @@ jobs:
       run: |
         pyinstaller --add-data tada.mp3:. --onefile vaccine-run-kakao.py
         chmod +x dist/vaccine-run-kakao
+    - name: Tar file
+      run: tar -cvf dist/vaccine-run-kakao.tar dist/vaccine-run-kakao
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
           name: Mac-Binary
-          path: dist/vaccine-run-kakao
+          path: dist/vaccine-run-kakao.tar


### PR DESCRIPTION
## Description
- https://github.com/actions/upload-artifact/issues/38

Check issue above about `upload-artifact`.
With this workaround, manual `chmod` is no longer needed.

## Related issues
- https://github.com/SJang1/korea-covid-19-remaining-vaccine-macro/issues/358
- https://github.com/SJang1/korea-covid-19-remaining-vaccine-macro/issues/527