### PR TITLE
ci: Release the program with action

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -91,6 +91,7 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
+        body: "Released via Github Actions"
         files: |
           artifacts/vaccine-run-kakao-windows.exe
           artifacts/vaccine-run-kakao-mac.tar

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -94,12 +94,3 @@ jobs:
         files: |
           artifacts/vaccine-run-kakao-windows.exe
           artifacts/vaccine-run-kakao-mac.tar
-      
-    - name: VirusTotal Scan
-      if: ${{ false }} # Remove this line only after add `VT_API_KEY` on secret env.
-      uses: crazy-max/ghaction-virustotal@v2
-      with:
-        vt_api_key: ${{ secrets.VT_API_KEY }}
-        update_release_body: true
-        files: |
-          artifacts/vaccine-run-kakao-windows.exe

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,6 +97,7 @@ jobs:
       
     - name: VirusTotal Scan
       if: ${{ false }} # Remove this line only after add `VT_API_KEY` on secret env.
+      uses: crazy-max/ghaction-virustotal@v2
       with:
         vt_api_key: ${{ secrets.VT_API_KEY }}
         update_release_body: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -99,5 +99,6 @@ jobs:
       if: ${{ false }} # Remove this line only after add `VT_API_KEY` on secret env.
       with:
         vt_api_key: ${{ secrets.VT_API_KEY }}
+        update_release_body: true
         files: |
           artifacts/vaccine-run-kakao-windows.exe

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -68,3 +68,36 @@ jobs:
       with:
           name: Mac-Binary
           path: dist/vaccine-run-kakao.tar
+
+  publish:
+    name: Release
+    permissions:
+      contents: write
+    needs: [Windows-Build, MacOS-Build]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+    - name: Download archived package
+      uses: actions/download-artifact@v2
+      with:
+        path: artifacts
+
+    - name: Rename file name for release
+      run: |
+        mv artifacts/Windows-Binary/vaccine-run-kakao.exe artifacts/vaccine-run-kakao-windows.exe
+        mv artifacts/Mac-Binary/vaccine-run-kakao.tar artifacts/vaccine-run-kakao-mac.tar
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          artifacts/vaccine-run-kakao-windows.exe
+          artifacts/vaccine-run-kakao-mac.tar
+      
+    - name: VirusTotal Scan
+      if: ${{ false }} # Remove this line only after add `VT_API_KEY` on secret env.
+      with:
+        vt_api_key: ${{ secrets.VT_API_KEY }}
+        files: |
+          artifacts/vaccine-run-kakao-windows.exe

--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -1,0 +1,18 @@
+name: VirusTotal scan after released
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  virustotal:
+    runs-on: ubuntu-latest
+    if: ${{ false }} # Remove this line only after add `VT_API_KEY` on secret env.
+    steps:
+    - name: VirusTotal Scan
+      uses: crazy-max/ghaction-virustotal@v2
+      with:
+        vt_api_key: ${{ secrets.VT_API_KEY }}
+        update_release_body: true
+        files: |
+          .exe$

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 build/
 dist/
 config.ini
+telegram.txt
 *.spec
 .idea/
 __pycache__/vaccine-run-kakao.cpython-39.pyc
 venv/
+# Who uses Pipfile?
+Pipfile
+Pipfile.lock


### PR DESCRIPTION
매번 빌드 끝나고 다운로드 하셔서 올리시는것 같아서, action으로 해결해봤습니다.
merge하신후 tag만 바로 추가하시면 됩니다. 빌드 실패시에는 작동이 안되도록 설계돼있으니 안심하세요.

Release Action이 끝나고나서 release를 수정하시면 됩니다.

일단 VirusTotal 스캐닝 기능(후 릴리즈에 VT 링크 추가)도 넣었는데 일단 비활성화 했습니다. (릴리즈/태그시에만 작동합니다.)
활성화 하시고싶으면 
1. VirusTotal에 가입하셔서 토큰을 발급받고 
2. Settings -> Secrets 으로 들어가셔서
3. New repository secret 누르시고 Name에 VT_API_TOKEN, 그 아래에 토큰 값을 넣으시면 됩니다.
4. 그 후에 마지막의 `if: ${{ false }}` 를 지우면 됩니다.

VT 관련 action은 [여기를 참조해주세요](https://github.com/marketplace/actions/virustotal-github-action)

[Release 결과(VT미포함)](https://github.com/MPThLee/korea-covid-19-remaining-vaccine-macro/releases/tag/v1.0.20-action-tag-release)