### PR TITLE
ci: Release as draft

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -127,6 +127,7 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
+        draft: true
         body: "Released via Github Actions"
         files: |
           artifacts/vaccine-run-kakao-windows.exe

--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -2,7 +2,7 @@ name: VirusTotal scan after released
 
 on:
   release:
-    types: [published, created, prereleased, released, edited]
+    types: [published]
 
 jobs:
   VirusTotal:
@@ -12,6 +12,7 @@ jobs:
       uses: crazy-max/ghaction-virustotal@v2
       with:
         vt_api_key: ${{ secrets.VT_API_KEY }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         update_release_body: true
         files: |
           .exe$


### PR DESCRIPTION
찾아보니까, Release가 Github-Actions 명의로 릴리즈/수정 등이 된 경우, 재귀가 될 수 있다고 간주되어 이벤트가 안돌아간다고 합니다.
https://github.community/t/actions-not-triggered-on-release/17944

그래서 draft로 먼저 파일만 올리는 형식으로 저장하도록 했습니다.
업로드가 완료되면 Draft를 수정해 Release를 하시면 이벤트가 트리거가 될겁니다.
(저도 장담은 못하겠네요...)


그런데 이번에 이벤트가 돌아갔네요...? 전부 넣어서 문제가 생긴거같습니다.