### PR TITLE
feat: cookie file config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@ build/
 dist/
 config.ini
 telegram.txt
+cookie.ini
 *.spec
 .idea/
 __pycache__/vaccine-run-kakao.cpython-39.pyc
 venv/
-# Who uses Pipfile?
+# Who uses Pipenv/Pipfile?
 Pipfile
 Pipfile.lock

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -25,20 +25,22 @@ def load_cookie_config():
         try:
             config_parser.read('config.ini')
             cookie_path = config_parser['chrome']['cookie_file']
+
             if cookie_path[0] == '~':
                 cookie_file = os.path.expanduser(cookie_path)
             elif "%" in cookie_path or "$" in cookie_path:
                 cookie_file = os.path.expandvars(cookie_path)
             else:
                 cookie_file = cookie_path
+
             cookie_file = os.path.abspath(cookie_file)
-            print(cookie_file)
+
             if os.path.exists(cookie_file):
                 return cookie_file
             else:
                 print("쿠키 파일이 존재하지 않습니다. 기본값으로 시도합니다.")
                 return None
-        except Exception as e: # 정확한 오류를 몰라서 전부 Exception
+        except Exception: # 정확한 오류를 몰라서 전부 Exception
             print("쿠키 파일을 찾는데 실패했습니다. 기본값으로 시도합니다.")
             return None
     return None

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -64,7 +64,7 @@ def load_cookie_config():
             indicator = cookie_file[0]
             if indicator == '~':
                 cookie_path = os.path.expanduser(cookie_file)
-            elif indicator == "%" or indicator == "$":
+            elif indicator in ('%', '$'):
                 cookie_path = os.path.expandvars(cookie_file)
             else:
                 cookie_path = cookie_file

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -21,9 +21,9 @@ urllib3.disable_warnings()
 # [chrome][cookie_file] 에서 경로를 로드함.
 def load_cookie_config():
     config_parser = configparser.ConfigParser(interpolation=None)
-    if os.path.exists('config.ini'):
+    if os.path.exists('cookie.ini'):
         try:
-            config_parser.read('config.ini')
+            config_parser.read('cookie.ini')
             cookie_path = config_parser['chrome']['cookie_file']
 
             if cookie_path[0] == '~':

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -20,17 +20,25 @@ urllib3.disable_warnings()
 # FIXME: jar 좀 어떻게 해서 깔끔하게 하기. 아래에 지정하면  `not defined` 표시.
 # [chrome][cookie_file] 에서 경로를 로드함.
 def load_cookie_config():
-    config_parser = configparser.ConfigParser()
+    config_parser = configparser.ConfigParser(interpolation=None)
     if os.path.exists('config.ini'):
         try:
             config_parser.read('config.ini')
-            cookie_file = os.path.abspath(config_parser['chrome']['cookie_file'])
+            cookie_path = config_parser['chrome']['cookie_file']
+            if cookie_path[0] == '~':
+                cookie_file = os.path.expanduser(cookie_path)
+            elif "%" in cookie_path or "$" in cookie_path:
+                cookie_file = os.path.expandvars(cookie_path)
+            else:
+                cookie_file = cookie_path
+            cookie_file = os.path.abspath(cookie_file)
+            print(cookie_file)
             if os.path.exists(cookie_file):
                 return cookie_file
             else:
                 print("쿠키 파일이 존재하지 않습니다. 기본값으로 시도합니다.")
                 return None
-        except Exception: # 정확한 오류를 몰라서 전부 Exception
+        except Exception as e: # 정확한 오류를 몰라서 전부 Exception
             print("쿠키 파일을 찾는데 실패했습니다. 기본값으로 시도합니다.")
             return None
     return None

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -17,36 +17,8 @@ import re
 search_time = 0.2  # 잔여백신을 해당 시간마다 한번씩 검색합니다. 단위: 초
 urllib3.disable_warnings()
 
-# FIXME: jar 좀 어떻게 해서 깔끔하게 하기. 아래에 지정하면  `not defined` 표시.
-# [chrome][cookie_file] 에서 경로를 로드함.
-def load_cookie_config():
-    config_parser = configparser.ConfigParser(interpolation=None)
-    if os.path.exists('cookie.ini'):
-        try:
-            config_parser.read('cookie.ini')
-            cookie_path = config_parser['chrome']['cookie_file']
-
-            if cookie_path[0] == '~':
-                cookie_file = os.path.expanduser(cookie_path)
-            elif "%" in cookie_path or "$" in cookie_path:
-                cookie_file = os.path.expandvars(cookie_path)
-            else:
-                cookie_file = cookie_path
-
-            cookie_file = os.path.abspath(cookie_file)
-
-            if os.path.exists(cookie_file):
-                return cookie_file
-            else:
-                print("쿠키 파일이 존재하지 않습니다. 기본값으로 시도합니다.")
-                return None
-        except Exception: # 정확한 오류를 몰라서 전부 Exception
-            return None
-    return None
-
-
-jar = browser_cookie3.chrome(cookie_file=load_cookie_config(), domain_name=".kakao.com")
-
+# 아래의 `load_cookie()` 에서 쿠키를 불러옴.
+jar=None
 
 # 기존 입력 값 로딩
 def load_config():
@@ -81,6 +53,36 @@ def load_config():
             return None, None, None, None, None
     return None, None, None, None, None
 
+# cookie.ini 안의 [chrome][cookie_file] 에서 경로를 로드함.
+def load_cookie_config():
+    config_parser = configparser.ConfigParser(interpolation=None)
+    if os.path.exists('cookie.ini'):
+        try:
+            config_parser.read('cookie.ini')
+            cookie_file = config_parser['chrome']['cookie_file']
+
+            if cookie_file[0] == '~':
+                cookie_path = os.path.expanduser(cookie_file)
+            elif "%" in cookie_file or "$" in cookie_file:
+                cookie_path = os.path.expandvars(cookie_file)
+            else:
+                cookie_path = cookie_path
+
+            cookie_path = os.path.abspath(cookie_path)
+
+            if os.path.exists(cookie_path):
+                return cookie_path
+            else:
+                print("지정된 경로에 쿠키 파일이 존재하지 않습니다. 기본값으로 시도합니다.")
+                return None
+        except Exception: # 정확한 오류를 몰라서 전부 Exception
+            return None
+    return None
+
+# 쿠키를 global jar 함수에 로드함.
+def load_cookie():
+    global jar
+    jar = browser_cookie3.chrome(cookie_file=load_cookie_config(), domain_name=".kakao.com")
 
 def check_user_info_loaded():
     user_info_api = 'https://vaccine.kakao.com/api/v1/user'
@@ -467,6 +469,7 @@ def find_vaccine(vaccine_type, top_x, top_y, bottom_x, bottom_y):
 
 
 def main_function():
+    load_cookie()
     check_user_info_loaded()
     previous_used_type, previous_top_x, previous_top_y, previous_bottom_x, previous_bottom_y = load_config()
     if previous_used_type is None:

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -59,11 +59,12 @@ def load_cookie_config():
     if os.path.exists('cookie.ini'):
         try:
             config_parser.read('cookie.ini')
-            cookie_file = config_parser['chrome']['cookie_file']
-
-            if cookie_file[0] == '~':
+            cookie_file = config_parser['chrome']['cookie_file'].strip()
+            
+            indicator = cookie_file[0]
+            if indicator == '~':
                 cookie_path = os.path.expanduser(cookie_file)
-            elif "%" in cookie_file or "$" in cookie_file:
+            elif indicator == "%" or indicator == "$":
                 cookie_path = os.path.expandvars(cookie_file)
             else:
                 cookie_path = cookie_file

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -17,7 +17,26 @@ import re
 search_time = 0.2  # 잔여백신을 해당 시간마다 한번씩 검색합니다. 단위: 초
 urllib3.disable_warnings()
 
-jar = browser_cookie3.chrome(domain_name=".kakao.com")
+# FIXME: jar 좀 어떻게 해서 깔끔하게 하기. 아래에 지정하면  `not defined` 표시.
+# [chrome][cookie_file] 에서 경로를 로드함.
+def load_cookie_config():
+    config_parser = configparser.ConfigParser()
+    if os.path.exists('config.ini'):
+        try:
+            config_parser.read('config.ini')
+            cookie_file = os.path.abspath(config_parser['chrome']['cookie_file'])
+            if os.path.exists(cookie_file):
+                return cookie_file
+            else:
+                print("쿠키 파일이 존재하지 않습니다. 기본값으로 시도합니다.")
+                return None
+        except Exception: # 정확한 오류를 몰라서 전부 Exception
+            print("쿠키 파일을 찾는데 실패했습니다. 기본값으로 시도합니다.")
+            return None
+    return None
+
+
+jar = browser_cookie3.chrome(cookie_file=load_cookie_config(), domain_name=".kakao.com")
 
 
 # 기존 입력 값 로딩

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -66,7 +66,7 @@ def load_cookie_config():
             elif "%" in cookie_file or "$" in cookie_file:
                 cookie_path = os.path.expandvars(cookie_file)
             else:
-                cookie_path = cookie_path
+                cookie_path = cookie_file
 
             cookie_path = os.path.abspath(cookie_path)
 

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -41,7 +41,6 @@ def load_cookie_config():
                 print("쿠키 파일이 존재하지 않습니다. 기본값으로 시도합니다.")
                 return None
         except Exception: # 정확한 오류를 몰라서 전부 Exception
-            print("쿠키 파일을 찾는데 실패했습니다. 기본값으로 시도합니다.")
             return None
     return None
 


### PR DESCRIPTION
Closes #694

일단 대충 짜봤는데,  졸려서 그런지 머리가 잘 안돌아가네요... 좀 더 깔끔하게 만들어야할텐데...


작동방식은 `cookie.ini`에
```ini
[chrome]
cookie_file=C:\Users\User\AppData\Local\Google\Chrome\User Data\Profile 1\Cookies
```
```ini
[chrome]
cookie_file=%LOCALAPPDATA%/Google/Chrome/User Data/Profile 1/Cookies
```
```ini
[chrome]
cookie_file=~/Library/Application Support/Google/Chrome/Profile 1/Cookies
```
```ini
[chrome]
cookie_file=$HOME/.config/google-chrome/Profile 1/Cookies
```

같은 식으로 넣으면 cookie파일이 존재하는지 확인하고, 없으면 기본값(=None)을 반환하는 방식입니다.
아마도 리눅스나 macOS 쓰시는분들도 될겁니다.

원래 예에에에전에 크롬 까신분들은 Default로 되는게 맞는데, 최근에 까신분들중 구글 로그인등을 하면 `Profile x`식으로 되는 경우가 있는것 같습니다.

그리고 구글 크롬으로 진행하는게 필수입니다. 코드를 보니까 꽤 전부터 Encryption이 적용되서, Key파일이 기본적으로 필요합니다. 이 키파일은 기본적으로 프로필 상관없이 같은 경로에 있습니다. 경로랑 키 스토어가 브라우저마다 달라지다보니 구글 크롬으로만 진행이 가능합니다.

#403 은 프로파일이 꼬일수 있는 문제가 있기 때문에, 아예 그냥 path지정식으로 바꿔봤습니다.
아마 이 기능이 추가되고나서 저 Discussion 내용을 수정하면 될거같습니다.

추가: `config.ini` 대신 `cookie.ini`으로 했습니다. 초기 구동부터 잘못될수 있는데 이때 `config.ini`가 생성되면 `load_config`랑 꼬일거같아서요.