### PR TITLE
fix: Jeju, Dokdo coordinates (fix #733)

### DIFF
--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -130,10 +130,10 @@ def fill_str_with_space(input_s, max_size=40, fill_char=" "):
 
 def is_in_range(coord_type, coord, user_min_x=-180.0, user_max_y=90.0):
     korea_coordinate = {      #Republic of Korea coordinate
-        "min_x": 124.965323,
-        "max_x": 130.416515,
-        "min_y": 34.082053,
-        "max_y": 38.634065
+        "min_x": 124.5,
+        "max_x": 132.0,
+        "min_y": 33.0,
+        "max_y": 38.9
     }
     try:
         if coord_type == "x":


### PR DESCRIPTION
제주도와 울릉도, 독도 등을 포함했습니다.
사실 더 정확한 데이터를 가져와야 맞겠지만, 데이터를 가지고있는게 없어서, [한국어 위키백과의 틀:위치 지도 대한민국](https://ko.wikipedia.org/wiki/%ED%8B%80:%EC%9C%84%EC%B9%98_%EC%A7%80%EB%8F%84_%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD)에 써져있는대로 가져왔습니다.

- https://github.com/SJang1/korea-covid-19-remaining-vaccine-macro/discussions/733