### PR TITLE
feat: kawlt cookie and search time on config

### DIFF
--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -139,7 +139,7 @@ def load_cookie():
 def load_search_time():
     global search_time
 
-    config_parser = configparser.ConfigParser()
+    config_parser = configparser.ConfigParser(interpolation=None)
     if os.path.exists('cookie.ini'):
         config_parser.read('cookie.ini')
         input_time = config_parser.getfloat(

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -58,6 +58,8 @@ def load_config():
 
 # cookie.ini 안의 [chrome][cookie_file] 에서 경로를 로드함.
 def load_cookie_config():
+    global jar
+
     config_parser = configparser.ConfigParser(interpolation=None)
     if os.path.exists('cookie.ini'):
         config_parser.read('cookie.ini')
@@ -105,7 +107,7 @@ def load_cookie():
     cookie_path = None
 
     if cookie_file is False:
-        return None
+        return
 
     if cookie_file is None:
         os_type = platform.system()
@@ -133,13 +135,12 @@ def load_cookie():
 
     jar = browser_cookie3.chrome(
         cookie_file=cookie_file, domain_name=".kakao.com")
-    return None
 
 
 def load_search_time():
     global search_time
 
-    config_parser = configparser.ConfigParser(interpolation=None)
+    config_parser = configparser.ConfigParser()
     if os.path.exists('cookie.ini'):
         config_parser.read('cookie.ini')
         input_time = config_parser.getfloat(
@@ -149,8 +150,6 @@ def load_search_time():
             search_time = 0.2
         else:
             search_time = input_time
-
-        return None
 
 
 def check_user_info_loaded():

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -61,7 +61,7 @@ def load_cookie_config():
     config_parser = configparser.ConfigParser(interpolation=None)
     if os.path.exists('cookie.ini'):
         config_parser.read('cookie.ini')
-        
+
         kawlt = config_parser.get('cookie', 'kawlt', fallback=None)
         if kawlt is not None:
             print("수동 입력된 쿠키 값으로 시도합니다.")
@@ -71,7 +71,8 @@ def load_cookie_config():
             return False
 
         try:
-            cookie_file = config_parser.get('chrome', 'cookie_file', fallback=None)
+            cookie_file = config_parser.get(
+                'chrome', 'cookie_file', fallback=None)
             if cookie_file is None:
                 return None
 
@@ -141,7 +142,8 @@ def load_search_time():
     config_parser = configparser.ConfigParser(interpolation=None)
     if os.path.exists('cookie.ini'):
         config_parser.read('cookie.ini')
-        input_time = config_parser.getfloat('config', 'search_time', fallback=0.2)
+        input_time = config_parser.getfloat(
+            'config', 'search_time', fallback=0.2)
 
         if input_time < 0.2:
             search_time = 0.2

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -130,9 +130,9 @@ def load_cookie():
 def load_search_time():
     global search_time
 
-    config_parser = configparser.ConfigParser(interpolation=None)
-    if os.path.exists('cookie.ini'):
-        config_parser.read('cookie.ini')
+    config_parser = configparser.ConfigParser()
+    if os.path.exists('config.ini'):
+        config_parser.read('config.ini')
         input_time = config_parser.getfloat(
             'config', 'search_time', fallback=0.2)
 

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -310,6 +310,7 @@ def dump_config(vaccine_type, top_x, top_y, bottom_x, bottom_y):
     conf["topY"] = top_y
     conf["botX"] = bottom_x
     conf["botY"] = bottom_y
+    conf["search_time"] = search_time
 
     with open("config.ini", "w") as config_file:
         config_parser.write(config_file)

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -60,9 +60,20 @@ def load_config():
 def load_cookie_config():
     config_parser = configparser.ConfigParser(interpolation=None)
     if os.path.exists('cookie.ini'):
+        config_parser.read('cookie.ini')
+        
+        kawlt = config_parser.get('cookie', 'kawlt', fallback=None)
+        if kawlt is not None:
+            print("수동 입력된 쿠키 값으로 시도합니다.")
+            jar = {
+                '_kawlt': kawlt.strip()
+            }
+            return False
+
         try:
-            config_parser.read('cookie.ini')
-            cookie_file = config_parser['chrome']['cookie_file'].strip()
+            cookie_file = config_parser.get('chrome', 'cookie_file', fallback=None)
+            if cookie_file is None:
+                return None
 
             indicator = cookie_file[0]
             if indicator == '~':
@@ -92,31 +103,52 @@ def load_cookie():
     cookie_file = load_cookie_config()
     cookie_path = None
 
-    os_type = platform.system()
-    if os_type == "Linux":
-        # browser_cookie3 also checks beta version of google chrome's cookie file.
-        cookie_path = os.path.expanduser(
-            "~/.config/google-chrome/Default/Cookies")
-        if os.path.exists(cookie_path) is False:
-            cookie_path = os.path.expanduser(
-                "~/.config/google-chrome-beta/Default/Cookies")
-    elif os_type == "Darwin":
-        cookie_path = os.path.expanduser(
-            "~/Library/Application Support/Google/Chrome/Default/Cookies")
-    elif os_type == "Windows":
-        cookie_path = os.path.expandvars(
-            "%LOCALAPPDATA%/Google/Chrome/User Data/Default/Cookies")
-    else:  # Jython?
-        print("지원하지 않는 환경입니다.")
-        close()
+    if cookie_file is False:
+        return None
 
-    if cookie_file is None and os.path.exists(cookie_path) is False:
-        print("기본 쿠키 파일 경로에 파일이 존재하지 않습니다. 아래 링크를 참조하여 쿠키 파일 경로를 지정해주세요.\n" +
-              "https://github.com/SJang1/korea-covid-19-remaining-vaccine-macro/discussions/403")
-        close()
+    if cookie_file is None:
+        os_type = platform.system()
+        if os_type == "Linux":
+            # browser_cookie3 also checks beta version of google chrome's cookie file.
+            cookie_path = os.path.expanduser(
+                "~/.config/google-chrome/Default/Cookies")
+            if os.path.exists(cookie_path) is False:
+                cookie_path = os.path.expanduser(
+                    "~/.config/google-chrome-beta/Default/Cookies")
+        elif os_type == "Darwin":
+            cookie_path = os.path.expanduser(
+                "~/Library/Application Support/Google/Chrome/Default/Cookies")
+        elif os_type == "Windows":
+            cookie_path = os.path.expandvars(
+                "%LOCALAPPDATA%/Google/Chrome/User Data/Default/Cookies")
+        else:  # Jython?
+            print("지원하지 않는 환경입니다.")
+            close()
+
+        if os.path.exists(cookie_path) is False:
+            print("기본 쿠키 파일 경로에 파일이 존재하지 않습니다. 아래 링크를 참조하여 쿠키 파일 경로를 지정해주세요.\n" +
+                  "https://github.com/SJang1/korea-covid-19-remaining-vaccine-macro/discussions/403")
+            close()
 
     jar = browser_cookie3.chrome(
         cookie_file=cookie_file, domain_name=".kakao.com")
+    return None
+
+
+def load_search_time():
+    global search_time
+
+    config_parser = configparser.ConfigParser(interpolation=None)
+    if os.path.exists('cookie.ini'):
+        config_parser.read('cookie.ini')
+        input_time = config_parser.getfloat('config', 'search_time', fallback=0.2)
+
+        if input_time < 0.2:
+            search_time = 0.2
+        else:
+            search_time = input_time
+
+        return None
 
 
 def check_user_info_loaded():
@@ -507,6 +539,7 @@ def find_vaccine(vaccine_type, top_x, top_y, bottom_x, bottom_y):
 
 def main_function():
     load_cookie()
+    load_search_time()
     check_user_info_loaded()
     previous_used_type, previous_top_x, previous_top_y, previous_bottom_x, previous_bottom_y = load_config()
     if previous_used_type is None:

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -145,8 +145,8 @@ def load_search_time():
         input_time = config_parser.getfloat(
             'config', 'search_time', fallback=0.2)
 
-        if input_time < 0.2:
-            search_time = 0.2
+        if input_time < 0.1:
+            search_time = 0.1
         else:
             search_time = input_time
 

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -63,15 +63,6 @@ def load_cookie_config():
     config_parser = configparser.ConfigParser(interpolation=None)
     if os.path.exists('cookie.ini'):
         config_parser.read('cookie.ini')
-
-        kawlt = config_parser.get('cookie', 'kawlt', fallback=None)
-        if kawlt is not None:
-            print("수동 입력된 쿠키 값으로 시도합니다.")
-            jar = {
-                '_kawlt': kawlt.strip()
-            }
-            return False
-
         try:
             cookie_file = config_parser.get(
                 'chrome', 'cookie_file', fallback=None)

--- a/vaccine-run-kakao.py
+++ b/vaccine-run-kakao.py
@@ -104,12 +104,11 @@ def load_cookie():
     global jar
 
     cookie_file = load_cookie_config()
-    cookie_path = None
-
     if cookie_file is False:
         return
 
     if cookie_file is None:
+        cookie_path = None
         os_type = platform.system()
         if os_type == "Linux":
             # browser_cookie3 also checks beta version of google chrome's cookie file.


### PR DESCRIPTION
## kawlt
Replaced by #787

개인적으로, 비권장 드리고 싶은 설정 방법입니다. 이걸로 매크로 유저 특정이 상대적으로 더 쉬워지기 때문입니다.

## search_time
`config.ini`의 `config` 섹션에 새 field `search_time`이 생겼습니다.
```ini
[config]
vac = VEN00013
topx = xx.yyyy
topy = xx.yyyy
botx = xx.yyyy
boty = xx.yyyy

; Here's new
search_time = 0.2
```
만약 제공되지 않으면, 기본값인 `0.2`로 fallback됩니다.
만약 제공된 값이 `0.1` 미만일시 `0.1`로 fallback 됩니다.
Close #699