### PR TITLE
fix v2: 기존 입력 없으면 오류 없이 넘어가기

### DIFF
--- a/kakao/config.py
+++ b/kakao/config.py
@@ -134,15 +134,18 @@ def load_config():
                     print("Y 또는 N을 입력해 주세요.")
 
             if skip_input:
-                # 설정 파일이 있으면 최근 로그인 정보 로딩
-                configuration = config_parser['config']
-                previous_used_type = configuration["VAC"]
-                previous_top_x = configuration["topX"]
-                previous_top_y = configuration["topY"]
-                previous_bottom_x = configuration["botX"]
-                previous_bottom_y = configuration["botY"]
-                previous_only_left = configuration["onlyLeft"] == "True"
-                return previous_used_type, previous_top_x, previous_top_y, previous_bottom_x, previous_bottom_y, previous_only_left
+                try:
+                    # 설정 파일이 있으면 최근 로그인 정보 로딩
+                    configuration = config_parser['config']
+                    previous_used_type = configuration["VAC"]
+                    previous_top_x = configuration["topX"]
+                    previous_top_y = configuration["topY"]
+                    previous_bottom_x = configuration["botX"]
+                    previous_bottom_y = configuration["botY"]
+                    previous_only_left = configuration["onlyLeft"] == "True"
+                    return previous_used_type, previous_top_x, previous_top_y, previous_bottom_x, previous_bottom_y, previous_only_left
+                except KeyError:
+                    print('기존에 입력한 정보가 없습니다.')
             else:
                 return None, None, None, None, None, None
         except ValueError:


### PR DESCRIPTION
Solves #824  ; fixes conflict from #792  .

지금 config.ini가 없는데 있다고 skip_input에 "Y"라고 말하면 보통사람이 이해 못 할 오류가 나타난다. try/except 통해서 skip_input가 "N"인 것처럼 넘어가게 한다.

<img width="1140" alt="Screen Shot 2021-08-03 at 11 04 53 AM" src="https://user-images.githubusercontent.com/40512164/127946876-694ca0ce-8761-482f-ada1-0e3f86de8b17.png">