### PR TITLE
refactor: Print on playsound exception

### DIFF
--- a/kakao/common.py
+++ b/kakao/common.py
@@ -9,11 +9,11 @@ from playsound import playsound, PlaysoundException
 
 def close(success=False):
     if success is True:
-        play_tada()
         send_msg("잔여백신 예약 성공!! \n 카카오톡지갑을 확인하세요.")
+        play_tada()
     elif success is False:
-        play_xylophon()
         send_msg("오류와 함께 잔여백신 예약 프로그램이 종료되었습니다.")
+        play_xylophon()
     else:
         pass
     input("Press Enter to close...")

--- a/kakao/common.py
+++ b/kakao/common.py
@@ -37,14 +37,14 @@ def play_tada():
     try:
         playsound(resource_path('sound/tada.mp3'))
     except PlaysoundException:
-        pass
+        print("ERROR: sound/tada.mp3를 재생하지 못했습니다.")
 
 
 def play_xylophon():
     try:
         playsound(resource_path('sound/xylophon.mp3'))
     except PlaysoundException:
-        pass
+        print("ERROR: sound/xylophon.mp3를 재생하지 못했습니다.")
 
 
 def send_msg(msg):


### PR DESCRIPTION
사운드 재생보다 결과 출력을 우선으로 하고,

만일에 대비하여 재생 오류가 발생하면 사용자가 인지할 수 있도록 `except` 에 출력문을 추가했습니다.