### PR TITLE
refactor: Clean parse response

### DIFF
--- a/kakao/request.py
+++ b/kakao/request.py
@@ -127,16 +127,20 @@ def try_reservation(organization_code, vaccine_type, jar):
             "orgCode": organization_code, "distance": None}
     response = requests.post(reservation_url, data=json.dumps(data), headers=headers_vaccine, cookies=jar, verify=False)
     response_json = json.loads(response.text)
-    for key in response_json:
-        value = response_json[key]
-        if key != 'code':
-            continue
-        if key == 'code' and value == "NO_VACANCY":
+    
+    if response_json.get('error'):
+        print("사용자 정보를 불러오는데 실패하였습니다.")
+        print("Chrome 브라우저에서 카카오에 제대로 로그인되어있는지 확인해주세요.")
+        close()
+    else:
+        reservation_status = response_json['code']
+        
+        if reservation_status == "NO_VACANCY":
             print("잔여백신 접종 신청이 선착순 마감되었습니다.")
-        elif key == 'code' and value == "TIMEOUT":
+        elif reservation_status == "TIMEOUT":
             print("TIMEOUT, 예약을 재시도합니다.")
             retry_reservation(organization_code, vaccine_type, jar)
-        elif key == 'code' and value == "SUCCESS":
+        elif reservation_status == "SUCCESS":
             print("백신접종신청 성공!!!")
             organization_code_success = response_json.get("organization")
             print(
@@ -157,13 +161,17 @@ def retry_reservation(organization_code, vaccine_type, jar):
             "orgCode": organization_code, "distance": None}
     response = requests.post(reservation_url, data=json.dumps(data), headers=headers_vaccine, cookies=jar, verify=False)
     response_json = json.loads(response.text)
-    for key in response_json:
-        value = response_json[key]
-        if key != 'code':
-            continue
-        if key == 'code' and value == "NO_VACANCY":
+    
+    if response_json.get('error'):
+        print("사용자 정보를 불러오는데 실패하였습니다.")
+        print("Chrome 브라우저에서 카카오에 제대로 로그인되어있는지 확인해주세요.")
+        close()
+    else:
+        reservation_status = response_json['code']
+        
+        if reservation_status == "NO_VACANCY":
             print("잔여백신 접종 신청이 선착순 마감되었습니다.")
-        elif key == 'code' and value == "SUCCESS":
+        elif reservation_status == "SUCCESS":
             print("백신접종신청 성공!!!")
             organization_code_success = response_json.get("organization")
             print(


### PR DESCRIPTION
`try_reservation` 함수에서 response 파싱하는 로직을 간소화했습니다.

`error`는 예외처리하고 나머지는 `code` 의 value만 캐싱해서 처리하므로, key와 value 모두 비교하는 이전 로직에 비해 처리가 빠를 것으로 예상됩니다.

`error`가 처리되는 것은 확인했는데, 그 외의 경우를 테스트하지 못했습니다. 핵심 모듈이니 신중한 리뷰 부탁드립니다.