### PR TITLE
ANY 옵션 삭제 및 복수 백신 선택, 모든 기관 탐색

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,8 +6,30 @@ name: Python package
 on: [push, pull_request]
 
 jobs:
+  lint:
+    name: Lint python
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-lint-cache-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-lint-cache-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        python -m pip install prospector pytest -r requirements.txt
+
+    - name: Lint via prospector
+      run: python -m prospector
+
   Windows-Build:
     runs-on: windows-latest
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +73,7 @@ jobs:
 
   MacOS-Build:
     runs-on: macos-latest
+    needs: lint
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,30 +6,8 @@ name: Python package
 on: [push, pull_request]
 
 jobs:
-  lint:
-    name: Lint python
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-lint-cache-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-lint-cache-
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip wheel
-        python -m pip install prospector pytest -r requirements.txt
-
-    - name: Lint via prospector
-      run: python -m prospector
-
   Windows-Build:
     runs-on: windows-latest
-    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +51,6 @@ jobs:
 
   MacOS-Build:
     runs-on: macos-latest
-    needs: lint
     strategy:
       fail-fast: false
       matrix:

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -96,7 +96,6 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
             print("AnyException : ", error)
             close()
 
-    print(found)
     vaccine_found_code = None
 
     if found is None:
@@ -104,6 +103,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
         return None
     else:
         vaccine_found_code = found.get('vaccineCode')
+        organization_code = found.get('orgCode')
 
     if vaccine_found_code and try_reservation(organization_code, vaccine_found_code, cookie):
         return None

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -50,7 +50,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
 
             try:
                 json_data = json.loads(response.text)
-                for x in json_data.get("organizations"):
+                for x in list(reversed(json_data.get("organizations"))):
                     if x.get('status') == "AVAILABLE" or x.get('leftCounts') != 0:
                         if prevSearch:
                             prev = list(filter(lambda org: org.get('orgName') == x.get('orgName'), prevSearch))

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -53,7 +53,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
                 for x in list(reversed(json_data.get("organizations"))):
                     if x.get('status') == "AVAILABLE" or x.get('leftCounts') != 0:
                         if prevSearch:
-                            prev = list(filter(lambda org: org.get('orgName') == x.get('orgName'), prevSearch))
+                            prev = list(filter(lambda org: org.get('orgCode') == x.get('orgCode'), prevSearch))
                             if len(prev) and prev[0].get('leftCounts') == x.get('leftCounts'):
                                 continue
 
@@ -63,6 +63,8 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
                             print(f"주소는: {x.get('address')} 입니다.")
                             done = True
                             break
+                        else:
+                            print("선택한 백신 종류가 없습니다.")
 
                 if not done:
                     prevSearch = json_data.get("organizations")
@@ -136,6 +138,11 @@ def try_reservation(organization_code, vaccine_type, jar):
             continue
         if key == 'code' and value == "NO_VACANCY":
             print("잔여백신 접종 신청이 선착순 마감되었습니다.")
+            for retry in range(0, 4):
+                result = retry_reservation(organization_code, vaccine_type, jar)
+                if result:
+                    close(success=True)
+
         elif key == 'code' and value == "TIMEOUT":
             print("TIMEOUT, 예약을 재시도합니다.")
             retry_reservation(organization_code, vaccine_type, jar)
@@ -166,6 +173,7 @@ def retry_reservation(organization_code, vaccine_type, jar):
             continue
         if key == 'code' and value == "NO_VACANCY":
             print("잔여백신 접종 신청이 선착순 마감되었습니다.")
+            return False
         elif key == 'code' and value == "SUCCESS":
             print("백신접종신청 성공!!!")
             organization_code_success = response_json.get("organization")

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -138,10 +138,7 @@ def try_reservation(organization_code, vaccine_type, jar):
             continue
         if key == 'code' and value == "NO_VACANCY":
             print("잔여백신 접종 신청이 선착순 마감되었습니다.")
-            for retry in range(0, 4):
-                result = retry_reservation(organization_code, vaccine_type, jar)
-                if result:
-                    close(success=True)
+            retry_reservation(organization_code, vaccine_type, jar)
 
         elif key == 'code' and value == "TIMEOUT":
             print("TIMEOUT, 예약을 재시도합니다.")
@@ -173,7 +170,6 @@ def retry_reservation(organization_code, vaccine_type, jar):
             continue
         if key == 'code' and value == "NO_VACANCY":
             print("잔여백신 접종 신청이 선착순 마감되었습니다.")
-            return False
         elif key == 'code' and value == "SUCCESS":
             print("백신접종신청 성공!!!")
             organization_code_success = response_json.get("organization")

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -66,7 +66,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
 
                 if not done:
                     prevSearch = json_data.get("organizations")
-                    #pretty_print(json_data)
+                    pretty_print(json_data)
                     print(datetime.now())
 
             except json.decoder.JSONDecodeError as decodeerror:

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -52,12 +52,15 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
 
                 for x in json_data.get("organizations"):
                     if x.get('status') == "AVAILABLE" or x.get('leftCounts') != 0:
-                        found = x
-                        done = True
-                        break
+                        print(f"{x.get('orgName')} 에서 백신을 {x.get('leftCounts')}개 발견했습니다.")
+                        found = check_vaccine_availablity(x, vaccine_type, cookie)
+                        if found:
+                            print(f"주소는: {x.get('address')} 입니다.")
+                            done = True
+                            break
 
                 if not done:
-                    pretty_print(json_data)
+                    #pretty_print(json_data)
                     print(datetime.now())
 
             except json.decoder.JSONDecodeError as decodeerror:
@@ -87,32 +90,18 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
             print("AnyException : ", error)
             close()
 
+    print(found)
+    vaccine_found_code = None
+
     if found is None:
         find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left)
         return None
-
-    print(f"{found.get('orgName')} 에서 백신을 {found.get('leftCounts')}개 발견했습니다.")
-    print(f"주소는 : {found.get('address')} 입니다.")
-    organization_code = found.get('orgCode')
+    else:
+        vaccine_found_code = found.get('vaccineCode')
 
     # 실제 백신 남은수량 확인
-    vaccine_found_code = None
 
-    if vaccine_type == "ANY":  # ANY 백신 선택
-        check_organization_url = f'https://vaccine.kakao.com/api/v3/org/org_code/{organization_code}'
-        check_organization_response = requests.get(check_organization_url, headers=headers_vaccine, cookies=cookie, verify=False)
-        check_organization_data = json.loads(check_organization_response.text).get("lefts")
-        for x in check_organization_data:
-            if x.get('leftCount') != 0:
-                print(f"{x.get('vaccineName')} 백신을 {x.get('leftCount')}개 발견했습니다.")
-                vaccine_found_code = x.get('vaccineCode')
-                break
-            else:
-                print(f"{x.get('vaccineName')} 백신이 없습니다.")
 
-    else:
-        vaccine_found_code = vaccine_type
-        print(f"{vaccine_found_code} 으로 예약을 시도합니다.")
 
     if vaccine_found_code and try_reservation(organization_code, vaccine_found_code, cookie):
         return None
@@ -120,6 +109,17 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
         find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bottom_y, only_left)
         return None
 
+
+def check_vaccine_availablity(data, vaccine_type, cookie):
+    check_organization_url = f'https://vaccine.kakao.com/api/v3/org/org_code/{data.get("orgCode")}'
+    check_organization_response = requests.get(check_organization_url, headers=headers_vaccine, cookies=cookie, verify=False)
+    check_organization_data = json.loads(check_organization_response.text).get("lefts")
+    for x in vaccine_type:
+        find = list(filter(lambda v: v.get('vaccineCode') == x and v.get('leftCount') != 0, check_organization_data))
+        if len(find):
+            print(f"{find[0].get('vaccineName')} {find[0].get('leftCount')}개가 있습니다.")
+            return find[0]
+    return False
 
 def try_reservation(organization_code, vaccine_type, jar):
     reservation_url = 'https://vaccine.kakao.com/api/v2/reservation'

--- a/kakao/request.py
+++ b/kakao/request.py
@@ -58,7 +58,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
                                 continue
 
                         print(f"{x.get('orgName')} 에서 백신을 {x.get('leftCounts')}개 발견했습니다.")
-                        found = check_vaccine_availablity(x, vaccine_type, cookie)
+                        found, target = check_vaccine_availablity(x, vaccine_type, cookie)
                         if found:
                             print(f"주소는: {x.get('address')} 입니다.")
                             done = True
@@ -103,7 +103,7 @@ def find_vaccine(cookie, search_time, vaccine_type, top_x, top_y, bottom_x, bott
         return None
     else:
         vaccine_found_code = found.get('vaccineCode')
-        organization_code = found.get('orgCode')
+        organization_code = target
 
     if vaccine_found_code and try_reservation(organization_code, vaccine_found_code, cookie):
         return None
@@ -120,8 +120,8 @@ def check_vaccine_availablity(data, vaccine_type, cookie):
         find = list(filter(lambda v: v.get('vaccineCode') == x and v.get('leftCount') != 0, check_organization_data))
         if len(find):
             print(f"{find[0].get('vaccineName')} {find[0].get('leftCount')}개가 있습니다.")
-            return find[0]
-    return False
+            return [find[0], data.get("orgCode")]
+    return [False, False]
 
 
 def try_reservation(organization_code, vaccine_type, jar):


### PR DESCRIPTION
SJang1#942 이슈에 대해 무의미해진 `ANY` 옵션을 삭제하고 여러 개의 백신을 선택할 수 있도록 수정했습니다.
백신 코드 입력 시 `VEN00014, VEN00013` 와 같이 입력하면 먼저 모더나를 찾고, 없으면 화이자를 찾습니다.

잔여백신이 가장 많은 접종 기관부터 백신 종류를 요청하고, 원하는 백신이 없으면 다음 기관으로 넘어갑니다.

~~다만 모든 기관에 대해 요청을 보내다 보니 좀 느려져서, `search_time`을 `0`으로 설정해도 0.5초 정도 소요됩니다.~~
https://github.com/SJang1/korea-covid-19-remaining-vaccine-macro/issues/942#issuecomment-894971991 반영해서 이전과 거의 같은 속도로 동작합니다.